### PR TITLE
Publish Extension to Visual Studio Marketplace

### DIFF
--- a/TemporaryProjects.Vsix/source.extension.vsixmanifest
+++ b/TemporaryProjects.Vsix/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="TemporaryProjects.2401a73f-ebe1-44b0-8a1f-4456ee9fecbe" Version="0.3" Language="en-US" Publisher="Jamie Cansdale" />
-        <DisplayName>Temporary Projects</DisplayName>
-        <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
+  <Metadata>
+    <Identity Id="TemporaryProjects.2401a73f-ebe1-44b0-8a1f-4456ee9fecbe" Version="0.4" Language="en-US" Publisher="Jamie Cansdale" />
+    <DisplayName>Temporary Projects</DisplayName>
+    <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
 </Description>
-        <MoreInfo>https://github.com/jcansdale/TemporaryProjects</MoreInfo>
-        <Icon>Resources\NewTempProjectCommandPackage.ico</Icon>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TemporaryProjects.14.0" Path="|TemporaryProjects.14.0;PkgdefProjectOutputGroup|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+    <MoreInfo>https://github.com/jcansdale/TemporaryProjects</MoreInfo>
+    <Icon>Resources\NewTempProjectCommandPackage.ico</Icon>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0)" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TemporaryProjects.14.0" Path="|TemporaryProjects.14.0;PkgdefProjectOutputGroup|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/TemporaryProjects.Vsix/source.extension.vsixmanifest
+++ b/TemporaryProjects.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TemporaryProjects.2401a73f-ebe1-44b0-8a1f-4456ee9fecbe" Version="0.4" Language="en-US" Publisher="Jamie Cansdale" />
+    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="0.4" Language="en-US" Publisher="Jamie Cansdale" />
     <DisplayName>Temporary Projects</DisplayName>
     <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
 </Description>

--- a/TemporaryProjects.Vsix/source.extension.vsixmanifest
+++ b/TemporaryProjects.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="0.4" Language="en-US" Publisher="Jamie Cansdale" />
+    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="0.4.1" Language="en-US" Publisher="Jamie Cansdale" />
     <DisplayName>Temporary Projects</DisplayName>
     <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
 </Description>

--- a/TemporaryProjects.sln
+++ b/TemporaryProjects.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporaryProjects.14.0", "T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5C29F08D-1FCB-4002-9042-F5F0A5F8B953}"
 	ProjectSection(SolutionItems) = preProject
+		publish.cmd = publish.cmd
 		publishManifest.json = publishManifest.json
 		README.md = README.md
 	EndProjectSection

--- a/TemporaryProjects.sln
+++ b/TemporaryProjects.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporaryProjects.14.0", "T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5C29F08D-1FCB-4002-9042-F5F0A5F8B953}"
 	ProjectSection(SolutionItems) = preProject
+		publishManifest.json = publishManifest.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/publish.cmd
+++ b/publish.cmd
@@ -1,0 +1,3 @@
+@set path="%VSInstallDir%\VSSDK\VisualStudioIntegration\Tools\Bin";%path%
+VsixPublisher login -publisherName JamieCansdale -personalAccessToken %personalAccessToken%
+VsixPublisher publish -payload TemporaryProjects.Vsix\bin\Debug\TemporaryProjects.vsix -publishManifest publishManifest.json

--- a/publishManifest.json
+++ b/publishManifest.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/vsix-publish",
+  "categories": [ "coding" ],
+  "identity": {
+    "internalName": "TemporaryProjects" // If not specified, we try to generate the name from the display name of the extension in the vsixmanifest file.
+    // Required if the display name is not the actual name of the extension.
+  },
+  "overview": "README.md", // Path to the "readme" file that gets uploaded to the Marketplace. Required.
+  "priceCategory": "free", // Either "free", "trial", or "paid". Defaults to "free".
+  "publisher": "JamieCansdale", // The name of the publisher. Required.
+  "private": false, // Specifies whether or not the extension should be public when uploaded. Defaults to false.
+  "qna": true, // Specifies whether or not the extension should have a Q&A section. Defaults to true.
+  "repo": "https://github.com/jcansdale/TemporaryProjects" // Not required.
+}


### PR DESCRIPTION
### What this PR does

- Bumps version number to 0.4
- Add `publishManifest.json` file
- Add `publish.cmd` script
- Changed `Identity.Id` to `TemporaryProjects.2401a73f-ebe1-44b0-8a1f-4456ee9fecbe`

I didn't want to change the extension `Identity.Id`, but I'm getting the following when I try to publish:
```
An error occurred while communicating with the marketplace: vsixId: The VSIX ID in the
provided file is already in use. Every extension needs to have an unique ID. Provide a file
with an unique ID.
```

### Notes

Extension can be published using the following command:
```
"%VSInstallDir%\VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" login -publisherName JamieCansdale -personalAccessToken xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
"%VSInstallDir%\VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" publish -payload TemporaryProjects.Vsix\bin\Debug\TemporaryProjects.vsix -publishManifest publishManifest.json
```

Fixes #7