### PR TITLE
Version stamp VSIX and assemblies using Nerdbank.GitVersioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning">
+      <Version>2.2.13</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/TemporaryProjects.14.0/Properties/AssemblyInfo.cs
+++ b/TemporaryProjects.14.0/Properties/AssemblyInfo.cs
@@ -18,16 +18,3 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TemporaryProjects.Vsix/Properties/AssemblyInfo.cs
+++ b/TemporaryProjects.Vsix/Properties/AssemblyInfo.cs
@@ -18,16 +18,3 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TemporaryProjects.Vsix/source.extension.vsixmanifest
+++ b/TemporaryProjects.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="0.4.1" Language="en-US" Publisher="Jamie Cansdale" />
+    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Jamie Cansdale" />
     <DisplayName>Temporary Projects</DisplayName>
     <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
 </Description>

--- a/TemporaryProjects.sln
+++ b/TemporaryProjects.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Publish.ps1 = Publish.ps1
 		publishManifest.json = publishManifest.json
 		README.md = README.md
+		version.json = version.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporaryProjects.Vsix", "TemporaryProjects.Vsix\TemporaryProjects.Vsix.csproj", "{97D8A3FD-A616-4E3A-AE6D-76C7EC4FEB8A}"

--- a/version.json
+++ b/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.5",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/v\\d+(?:.\\d+)?$" // we also release out of vNN branches
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
### What this PR does

- Setup `Nerdbank.GitVersioning` using `nbgv install`

### Note

You might need to explicitly `Restore NuGet Packages` when changing to this branch, because `it 
 looks like Nerdbank.GitVersioning` will be silently ignored if the package hasn't been installed.