### PR TITLE
Update for Visual Studio 2019

### DIFF
--- a/TemporaryProjects.14.0/TemporaryProjects.14.0.csproj
+++ b/TemporaryProjects.14.0/TemporaryProjects.14.0.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>

--- a/TemporaryProjects.Vsix/TemporaryProjects.Vsix.csproj
+++ b/TemporaryProjects.Vsix/TemporaryProjects.Vsix.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />

--- a/TemporaryProjects.Vsix/source.extension.vsixmanifest
+++ b/TemporaryProjects.Vsix/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Jamie Cansdale" />
-    <DisplayName>Temporary Projects</DisplayName>
-    <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
+    <Metadata>
+        <Identity Id="TemporaryProjects.530d4cf0-0e05-449f-945b-d14dcf6eb95d" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Jamie Cansdale" />
+        <DisplayName>Temporary Projects</DisplayName>
+        <Description xml:space="preserve">Add `File &gt; New &gt; Temporary Project...` command to create a projects in a temporary directory.
 </Description>
-    <MoreInfo>https://github.com/jcansdale/TemporaryProjects</MoreInfo>
-    <Icon>Resources\NewTempProjectCommandPackage.ico</Icon>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TemporaryProjects.14.0" Path="|TemporaryProjects.14.0;PkgdefProjectOutputGroup|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+        <MoreInfo>https://github.com/jcansdale/TemporaryProjects</MoreInfo>
+        <Icon>Resources\NewTempProjectCommandPackage.ico</Icon>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 17.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TemporaryProjects.14.0" Path="|TemporaryProjects.14.0;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
- Update `source.extension.vsixmanifest` to install for 2019
- Update projects to ignore `MinimumVisualStudioVersion`
```
<MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
```