### PR TITLE
Create zero-impact temp projects

### DIFF
--- a/TemporaryProjects.14.0/NewTempProjectCommandPackage.cs
+++ b/TemporaryProjects.14.0/NewTempProjectCommandPackage.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Threading;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
+using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio;
 
 namespace TemporaryProjects
 {
@@ -14,8 +17,17 @@ namespace TemporaryProjects
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     public sealed class NewTempProjectCommandPackage : AsyncPackage
     {
+        ProjectsLocationEvent saveAllContext;
+
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dte = await GetServiceAsync(typeof(SDTE)) as DTE;
+            saveAllContext = new ProjectsLocationEvent(dte,
+                VSConstants.GUID_VSStandardCommandSet97,
+                (int)VSConstants.VSStd97CmdID.SaveSolution /*File.SaveAll*/);
+
             await NewTempProjectCommand.InitializeAsync(this);
         }
     }

--- a/TemporaryProjects.14.0/ProjectsLocationContext.cs
+++ b/TemporaryProjects.14.0/ProjectsLocationContext.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+
+namespace TemporaryProjects
+{
+    public class ProjectsLocationEvent
+    {
+        readonly DTE dte;
+        readonly CommandEvents commandEvents;
+        IDisposable context;
+
+        public ProjectsLocationEvent(DTE dte, Guid guid, int id)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            this.dte = dte;
+            commandEvents = dte.Events.CommandEvents[guid.ToString("B"), id];
+            commandEvents.BeforeExecute += BeforeExecute;
+            commandEvents.AfterExecute += AfterExecute;
+        }
+
+        void BeforeExecute(string Guid, int ID, object CustomIn, object CustomOut, ref bool CancelDefault)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            context = new TempProjectLocationContext(dte);
+        }
+
+        void AfterExecute(string Guid, int ID, object CustomIn, object CustomOut)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            context?.Dispose();
+            context = null;
+        }
+    }
+}

--- a/TemporaryProjects.14.0/TempProjectLocationContext.cs
+++ b/TemporaryProjects.14.0/TempProjectLocationContext.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+
+namespace TemporaryProjects
+{
+    public class TempProjectLocationContext : IDisposable
+    {
+        readonly Property projectsLocation;
+        readonly string location;
+
+        public TempProjectLocationContext(DTE dte)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            projectsLocation = dte.Properties["Environment", "ProjectsAndSolution"].Item("ProjectsLocation");
+            location = (string)projectsLocation.Value;
+            var tempPath = string.Format(@"Temp\{0:yyyy-MM-dd}\", DateTime.Now);
+            var tempLocation = Path.Combine(location, tempPath);
+            projectsLocation.Value = tempLocation;
+        }
+
+        public void Dispose()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            projectsLocation.Value = location;
+        }
+    }
+}

--- a/TemporaryProjects.14.0/TemporaryProjects.14.0.csproj
+++ b/TemporaryProjects.14.0/TemporaryProjects.14.0.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="NewTempProjectCommand.cs" />
     <Compile Include="NewTempProjectCommandPackage.cs" />
+    <Compile Include="ProjectsLocationContext.cs" />
     <Compile Include="StartPageExtender.cs" />
     <Compile Include="StartPageExtenderPackage.cs" />
     <Compile Include="TemporaryProjects.cs">
@@ -66,6 +67,7 @@
       <DependentUpon>TemporaryProjects.vsct</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TempProjectLocationContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Key.snk" />


### PR DESCRIPTION
Set the `ProjectsAndSolution/SaveNewProjects` option to false when creating temp projects. This allows choosing a project name be deferred until when the project is saved or for the project to be abandoned completely.

Fixes #18